### PR TITLE
next

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -31,6 +31,11 @@ SPOTIFY_API_BASE_URL = URL.build(
     path='/v1'
 )
 
+# A top search result below this threshold will not be considered for playback
+# and Blanco will fall back to YouTube search. See
+# jockey_helpers.py:check_similarity_weighted() for the computation.
+SPOTIFY_CONFIDENCE_THRESHOLD = 55
+
 SPOTIFY_403_ERR_MSG = ''.join([
     '**Error 403** encountered while trying to {}.\n',
     'This is likely because this instance of Blanco uses Spotify API credentials ',

--- a/utils/jockey.py
+++ b/utils/jockey.py
@@ -347,6 +347,14 @@ class Jockey(Player['BlancoBot']):
         if not self._bot.config.lastfm_api_key or not self._bot.config.lastfm_shared_secret:
             return
 
+        # Check if track has an ISRC
+        if item.isrc is None:
+            self._logger.error(
+                'Refusing to scrobble without ISRC: `%s\'',
+                item.title
+            )
+            return
+
         # Check if track can be scrobbled
         time_now = int(time())
         try:


### PR DESCRIPTION
- Fall back to YouTube if the top Spotify search result has a confidence value below 55
- Don't scrobble items without an ISRC to prevent polluting Last.fm playback history
- The `Shuffle` button is now properly labeled on every sent Now Playing card, depending on the queue shuffle state at that point in time (closes #36)