### PR TITLE
Release 0.5.5

### DIFF
--- a/cogs/player/jockey.py
+++ b/cogs/player/jockey.py
@@ -594,8 +594,11 @@ class Jockey(Player['BlancoBot']):
         # Edit message
         try:
             await np_msg.edit(embed=self.now_playing())
-        except (HTTPException, Forbidden):
-            self._logger.warning(
-                'Failed to edit now playing message for %s',
-                self.guild.name
-            )
+        except (HTTPException, Forbidden) as exc:
+            # Ignore 404
+            if not isinstance(exc, NotFound):
+                self._logger.warning(
+                    'Failed to edit now playing message for %s: %s',
+                    self.guild.name,
+                    exc
+                )

--- a/cogs/player/lavalink_client.py
+++ b/cogs/player/lavalink_client.py
@@ -32,7 +32,7 @@ def filter_results(query: str, search_results: List['Track']) -> List[LavalinkRe
         # if the original query did not ask for it
         valid = True
         for word in BLACKLIST:
-            if word in result.title.lower() and not word in query.lower():
+            if word in result.title.lower() and word not in query.lower():
                 valid = False
                 break
 

--- a/cogs/player/lavalink_client.py
+++ b/cogs/player/lavalink_client.py
@@ -9,32 +9,12 @@ from typing import TYPE_CHECKING, List, Optional
 from mafic import Playlist, SearchType, TrackLoadException
 
 from dataclass.lavalink_result import LavalinkResult
+from utils.constants import BLACKLIST
 from utils.exceptions import LavalinkSearchError
 from utils.fuzzy import check_similarity
 
 if TYPE_CHECKING:
     from mafic import Node, Track
-
-
-BLACKLIST = (
-    '3d'
-    '8d',
-    'cover',
-    'instrumental',
-    'karaoke',
-    'live',
-    'loop',
-    'mashup',
-    'minus one',
-    'performance',
-    'piano',
-    'remix',
-    'rendition',
-    'reverb',
-    'slowed',
-    'sped',
-    'speed'
-)
 
 
 def filter_results(query: str, search_results: List['Track']) -> List[LavalinkResult]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ sentry-sdk==1.39.2
 six==1.16.0
 sniffio==1.3.0
 spotipy==2.23.0
+tenacity==8.2.3
 thefuzz==0.20.0
 typing_extensions==4.9.0
 urllib3==2.1.0

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -38,6 +38,28 @@ SPOTIFY_API_BASE_URL = URL.build(
     path='/v1'
 )
 
+# Results with these words in the title will be filtered out
+# unless the user's query also contains these words.
+BLACKLIST = (
+    '3d'
+    '8d',
+    'cover',
+    'instrumental',
+    'karaoke',
+    'live',
+    'loop',
+    'mashup',
+    'minus one',
+    'performance',
+    'piano',
+    'remix',
+    'rendition',
+    'reverb',
+    'slowed',
+    'sped',
+    'speed'
+)
+
 # A top search result below this threshold will not be considered for playback
 # and Blanco will fall back to YouTube search. See
 # jockey_helpers.py:check_similarity_weighted() for the computation.

--- a/utils/spotify_client.py
+++ b/utils/spotify_client.py
@@ -27,7 +27,7 @@ def log_call(retry_state: RetryCallState) -> None:
     """
     RETRY_LOGGER.debug(
         'Calling Spotify API: %s(%s, %s)',
-        retry_state.fn,
+        getattr(retry_state.fn, '__name__', repr(retry_state.fn)),
         retry_state.args,
         retry_state.kwargs
     )
@@ -37,16 +37,18 @@ def log_failure(retry_state: RetryCallState) -> None:
     """
     Logs a retry attempt.
     """
+    func_name = getattr(retry_state.fn, '__name__', repr(retry_state.fn))
+
     # Log outcome
     if retry_state.outcome is not None:
-        RETRY_LOGGER.debug('%s() failed: %s', retry_state.fn, retry_state.outcome)
+        RETRY_LOGGER.debug('%s() failed: %s', func_name, retry_state.outcome)
         RETRY_LOGGER.debug('  Exception: %s', retry_state.outcome.exception())
         RETRY_LOGGER.debug('  Args: %s', retry_state.args)
         RETRY_LOGGER.debug('  Kwargs: %s', retry_state.kwargs)
     
     RETRY_LOGGER.warning(
         'Retrying %s(), attempt %s',
-        retry_state.fn,
+        func_name,
         retry_state.attempt_number
     )
 

--- a/utils/spotify_client.py
+++ b/utils/spotify_client.py
@@ -45,7 +45,7 @@ def log_failure(retry_state: RetryCallState) -> None:
         RETRY_LOGGER.debug('  Exception: %s', retry_state.outcome.exception())
         RETRY_LOGGER.debug('  Args: %s', retry_state.args)
         RETRY_LOGGER.debug('  Kwargs: %s', retry_state.kwargs)
-    
+
     RETRY_LOGGER.warning(
         'Retrying %s(), attempt %s',
         func_name,

--- a/utils/spotify_client.py
+++ b/utils/spotify_client.py
@@ -83,6 +83,11 @@ class Spotify:
             return default
         return art[0]['url']
 
+    @retry(
+        retry=retry_if_exception_type(RequestsConnectionError),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1) + wait_random(0, 2)
+    )
     def get_artist_top_tracks(self, artist_id: str) -> List[SpotifyTrack]:
         """
         Returns a list of SpotifyTrack objects for a given artist's
@@ -94,6 +99,11 @@ class Spotify:
 
         return [extract_track_info(track) for track in response['tracks']]
 
+    @retry(
+        retry=retry_if_exception_type(RequestsConnectionError),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1) + wait_random(0, 2)
+    )
     def get_track_art(self, track_id: str) -> str:
         """
         Returns the track artwork for a given track ID.
@@ -103,6 +113,11 @@ class Spotify:
             raise SpotifyInvalidURLError(f'spotify:track:{track_id}')
         return self.__get_art(result['album']['images'])
 
+    @retry(
+        retry=retry_if_exception_type(RequestsConnectionError),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1) + wait_random(0, 2)
+    )
     def get_track(self, track_id: str) -> SpotifyTrack:
         """
         Returns a SpotifyTrack object for a given track ID.
@@ -123,6 +138,11 @@ class Spotify:
 
         return extract_track_info(result)
 
+    @retry(
+        retry=retry_if_exception_type(RequestsConnectionError),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1) + wait_random(0, 2)
+    )
     def get_tracks(self, list_type: str, list_id: str) -> Tuple[str, str, List[SpotifyTrack]]:
         """
         Returns a list of SpotifyTrack objects for a given album or playlist ID.

--- a/utils/spotify_client.py
+++ b/utils/spotify_client.py
@@ -4,6 +4,10 @@ Wrapper for the spotipy Spotify client which supports pagination by default.
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from requests.exceptions import ConnectionError
+from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
+                      wait_fixed, wait_random)
+
 import spotipy
 
 from dataclass.spotify import SpotifyResult, SpotifyTrack
@@ -191,6 +195,11 @@ class Spotify:
 
         return [extract_track_info(track) for track in response['tracks']['items']]
 
+    @retry(
+        retry=retry_if_exception_type(ConnectionError),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1) + wait_random(0, 2)
+    )
     def search(self, query: str, search_type: str) -> List[SpotifyResult]:
         """
         Searches Spotify for a given artist, album, or playlist,

--- a/utils/spotify_client.py
+++ b/utils/spotify_client.py
@@ -4,7 +4,7 @@ Wrapper for the spotipy Spotify client which supports pagination by default.
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_fixed, wait_random)
 
@@ -187,7 +187,7 @@ class Spotify:
         ]
 
     @retry(
-        retry=retry_if_exception_type(ConnectionError),
+        retry=retry_if_exception_type(RequestsConnectionError),
         stop=stop_after_attempt(3),
         wait=wait_fixed(1) + wait_random(0, 2)
     )
@@ -214,7 +214,7 @@ class Spotify:
         return results[:limit]
 
     @retry(
-        retry=retry_if_exception_type(ConnectionError),
+        retry=retry_if_exception_type(RequestsConnectionError),
         stop=stop_after_attempt(3),
         wait=wait_fixed(1) + wait_random(0, 2)
     )

--- a/utils/spotify_client.py
+++ b/utils/spotify_client.py
@@ -202,11 +202,11 @@ class Spotify:
         if response is None or len(response['tracks']['items']) == 0:
             raise SpotifyNoResultsError
 
-        # Filter out tracks with blacklisted words in the title
+        # Filter out tracks with blacklisted words not in the original query
         results = []
         for result in response['tracks']['items']:
             for word in BLACKLIST:
-                if word in result['name'].lower():
+                if word in result['name'].lower() and word not in query.lower():
                     break
             else:
                 results.append(extract_track_info(result))

--- a/utils/spotify_client.py
+++ b/utils/spotify_client.py
@@ -185,6 +185,11 @@ class Spotify:
             for x in tracks
         ]
 
+    @retry(
+        retry=retry_if_exception_type(ConnectionError),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1) + wait_random(0, 2)
+    )
     def search_track(self, query, limit: int = 1) -> List[SpotifyTrack]:
         """
         Searches Spotify for a given query and returns a list of SpotifyTrack objects.


### PR DESCRIPTION
- Fix playback failures on Google Cloud caused by Spotify API timeouts (just retry it 3 times)
- Apply Lavalink YT result blacklisting logic to Spotify results
- Ignore 404 message not found errors when trying to edit the Now Playing view
